### PR TITLE
Feature/multiple return

### DIFF
--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40.hpp
@@ -15,17 +15,17 @@ constexpr size_t BLOCKS_PER_PACKET = 10;
 constexpr size_t BLOCK_SIZE = RAW_MEASURE_SIZE * LASER_COUNT + SOB_ANGLE_SIZE;
 constexpr size_t TIMESTAMP_SIZE = 4;
 constexpr size_t FACTORY_INFO_SIZE = 1;
-constexpr size_t ECHO_SIZE = 1;
+constexpr size_t RETURN_SIZE = 1;
 constexpr size_t RESERVE_SIZE = 8;
 constexpr size_t REVOLUTION_SIZE = 2;
-constexpr size_t INFO_SIZE = TIMESTAMP_SIZE + FACTORY_INFO_SIZE + ECHO_SIZE + RESERVE_SIZE + REVOLUTION_SIZE;
+constexpr size_t INFO_SIZE = TIMESTAMP_SIZE + FACTORY_INFO_SIZE + RETURN_SIZE + RESERVE_SIZE + REVOLUTION_SIZE;
 constexpr size_t UTC_TIME = 6;
 constexpr size_t PACKET_SIZE = BLOCK_SIZE * BLOCKS_PER_PACKET + INFO_SIZE + UTC_TIME;
 constexpr size_t SEQ_NUM_SIZE = 4;
 constexpr double LASER_RETURN_TO_DISTANCE_RATE = 0.004;
-constexpr uint32_t STRONGEST_ECHO = 0x37;
-constexpr uint32_t LAST_ECHO = 0x38;
-constexpr uint32_t DUAL_ECHO = 0x39;
+constexpr uint32_t STRONGEST_RETURN = 0x37;
+constexpr uint32_t LAST_RETURN = 0x38;
+constexpr uint32_t DUAL_RETURN = 0x39;
 
 struct Unit
 {
@@ -45,7 +45,7 @@ struct Packet
   Block blocks[BLOCKS_PER_PACKET];
   struct tm t;
   uint32_t usec;
-  uint32_t echo;
+  uint32_t return_mode;
 };
 
 }  // namespace pandar40

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
@@ -20,7 +20,7 @@ public:
   };
   enum ReturnType : int8_t
   {
-    INVALID = -1,
+    INVALID = 0,
     SINGLE_STRONGEST,
     SINGLE_LAST,
     DUAL_STRONGEST_FIRST,

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
@@ -30,7 +30,7 @@ public:
     DUAL_ONLY,
   };
 
-  Pandar40Decoder(Calibration& calibration, float scan_phase = 0.0f, ReturnMode return_mode = ReturnMode::DUAL);
+  Pandar40Decoder(Calibration& calibration, float scan_phase = 0.0f, double dual_return_distance_threshold = 0.1, ReturnMode return_mode = ReturnMode::DUAL);
   void unpack(const pandar_msgs::PandarPacket& raw_packet) override;
   bool hasScanned() override;
   PointcloudXYZIRADT getPointcloud() override;
@@ -51,6 +51,7 @@ private:
   std::array<size_t, LASER_COUNT> firing_order_;
 
   ReturnMode return_mode_;
+  double dual_return_distance_threshold_;
   Packet packet_;
 
   PointcloudXYZIRADT scan_pc_;

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
@@ -18,6 +18,17 @@ public:
     STRONGEST,
     LAST,
   };
+  enum ReturnType : int8_t
+  {
+    INVALID = -1,
+    SINGLE_STRONGEST,
+    SINGLE_LAST,
+    DUAL_STRONGEST_FIRST,
+    DUAL_STRONGEST_LAST,
+    DUAL_WEAK_FIRST,
+    DUAL_WEAK_LAST,
+    DUAL_ONLY,
+  };
 
   Pandar40Decoder(Calibration& calibration, float scan_phase = 0.0f, ReturnMode return_mode = ReturnMode::DUAL);
   void unpack(const pandar_msgs::PandarPacket& raw_packet) override;
@@ -26,6 +37,7 @@ public:
 
 private:
   bool parsePacket(const pandar_msgs::PandarPacket& raw_packet);
+  PointXYZIRADT build_point(int block_id, int unit_id, int8_t return_type);
   PointcloudXYZIRADT convert(const int block_id);
   PointcloudXYZIRADT convert_dual(const int block_id);
 

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt.hpp
@@ -22,7 +22,7 @@ constexpr size_t BODY_SIZE = BLOCK_SIZE * BLOCK_NUM;
 constexpr size_t RESERVED_SIZE = 10;
 constexpr size_t ENGINE_VELOCITY = 2;
 constexpr size_t TIMESTAMP_SIZE = 4;
-constexpr size_t ECHO_SIZE = 1;
+constexpr size_t RETURN_SIZE = 1;
 constexpr size_t FACTORY_SIZE = 1;
 constexpr size_t UTC_SIZE = 6;
 constexpr size_t SEQUENCE_SIZE = 4;
@@ -33,9 +33,9 @@ constexpr size_t PACKET_TAIL_WITHOUT_UDPSEQ_SIZE = 24;
 constexpr size_t PACKET_SIZE = HEAD_SIZE + BODY_SIZE + PACKET_TAIL_SIZE;
 constexpr size_t PACKET_WITHOUT_UDPSEQ_SIZE = HEAD_SIZE + BODY_SIZE + PACKET_TAIL_WITHOUT_UDPSEQ_SIZE;
 
-constexpr uint32_t FIRST_ECHO = 0x33;
-constexpr uint32_t LAST_ECHO = 0x38;
-constexpr uint32_t DUAL_ECHO = 0x3B;
+constexpr uint32_t FIRST_RETURN = 0x33;
+constexpr uint32_t LAST_RETURN = 0x38;
+constexpr uint32_t DUAL_RETURN = 0x3B;
 
 struct Header
 {
@@ -68,7 +68,7 @@ struct Packet
   Header header;
   Block blocks[BLOCK_NUM];
   uint32_t usec;  // ms
-  uint32_t echo;
+  uint32_t return_mode;
   tm t;
 };
 }  // namespace pandar_qt

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
@@ -20,7 +20,7 @@ public:
   };
   enum ReturnType : int8_t
   {
-    INVALID = -1,
+    INVALID = 0,
     SINGLE_FIRST,
     SINGLE_LAST,
     DUAL_FIRST,

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
@@ -18,9 +18,19 @@ public:
     FIRST,
     LAST,
   };
+  enum ReturnType : int8_t
+  {
+    INVALID = -1,
+    SINGLE_FIRST,
+    SINGLE_LAST,
+    DUAL_FIRST,
+    DUAL_LAST,
+    DUAL_ONLY,
+  };
 
   PandarQTDecoder(Calibration& calibration, float scan_phase = 0.0f, ReturnMode return_mode = ReturnMode::DUAL);
   void unpack(const pandar_msgs::PandarPacket& raw_packet) override;
+  PointXYZIRADT build_point(int block_id, int unit_id, int8_t return_type);
   bool hasScanned() override;
   PointcloudXYZIRADT getPointcloud() override;
 

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
@@ -28,7 +28,7 @@ public:
     DUAL_ONLY,
   };
 
-  PandarQTDecoder(Calibration& calibration, float scan_phase = 0.0f, ReturnMode return_mode = ReturnMode::DUAL);
+  PandarQTDecoder(Calibration& calibration, float scan_phase = 0.0f, double dual_return_distance_threshold = 0.1, ReturnMode return_mode = ReturnMode::DUAL);
   void unpack(const pandar_msgs::PandarPacket& raw_packet) override;
   PointXYZIRADT build_point(int block_id, int unit_id, int8_t return_type);
   bool hasScanned() override;
@@ -47,6 +47,7 @@ private:
   std::array<float, BLOCK_NUM> block_offset_dual_;
 
   ReturnMode return_mode_;
+  double dual_return_distance_threshold_;
   Packet packet_;
 
   PointcloudXYZIRADT scan_pc_;

--- a/pandar_pointcloud/include/pandar_pointcloud/pandar_cloud.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/pandar_cloud.hpp
@@ -23,6 +23,7 @@ private:
   pcl::PointCloud<PointXYZIR>::Ptr convertPointcloud(const pcl::PointCloud<PointXYZIRADT>::ConstPtr& input_pointcloud);
 
   std::string model_;
+  std::string return_mode_;
   std::string device_ip_;
   std::string calibration_path_;
   double scan_phase_;

--- a/pandar_pointcloud/include/pandar_pointcloud/pandar_cloud.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/pandar_cloud.hpp
@@ -26,6 +26,7 @@ private:
   std::string return_mode_;
   std::string device_ip_;
   std::string calibration_path_;
+  double dual_return_distance_threshold_;
   double scan_phase_;
 
   ros::Subscriber pandar_packet_sub_;

--- a/pandar_pointcloud/include/pandar_pointcloud/point_types.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/point_types.hpp
@@ -20,6 +20,7 @@ struct PointXYZIRADT
   uint16_t ring;
   float azimuth;
   float distance;
+  int8_t return_type;
   double time_stamp;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
@@ -35,5 +36,6 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(pandar_pointcloud::PointXYZIR,
 POINT_CLOUD_REGISTER_POINT_STRUCT(pandar_pointcloud::PointXYZIRADT,
                                   (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(
                                       std::uint16_t, ring, ring)(float, azimuth, azimuth)(float, distance,
-                                                                                          distance)(double, time_stamp,
-                                                                                                    time_stamp))
+                                                                                          distance)(int8_t, return_type,
+                                                                                          return_type)(double, time_stamp,
+                                                                                                        time_stamp))

--- a/pandar_pointcloud/launch/pandar40P.launch
+++ b/pandar_pointcloud/launch/pandar40P.launch
@@ -6,6 +6,7 @@
   <arg name="lidar_port"  default="2368"/>
   <arg name="gps_port"  default="10110"/>
   <arg name="scan_phase"  default="0"/>
+  <arg name="dual_return_distance_threshold" default="0.1"/>
   <arg name="return_mode" default="Dual"/>
   <arg name="model" default="Pandar40P"/>
   <arg name="frame_id" default="pandar"/>
@@ -34,6 +35,7 @@
     <remap from="pandar_points_ex" to="pointcloud_raw_ex" />
     <param name="scan_phase" type="double" value="$(arg scan_phase)"/>
     <param name="return_mode"  type="string" value="$(arg return_mode)"/>
+    <param name="dual_return_distance_threshold"  type="double" value="$(arg dual_return_distance_threshold)"/>
     <param name="model" type="string" value="$(arg model)"/>
     <param name="device_ip" type="string" value="$(arg device_ip)"/>
     <param name="calibration" type="string" value="$(arg calibration)"/>

--- a/pandar_pointcloud/launch/pandar40P.launch
+++ b/pandar_pointcloud/launch/pandar40P.launch
@@ -6,6 +6,7 @@
   <arg name="lidar_port"  default="2368"/>
   <arg name="gps_port"  default="10110"/>
   <arg name="scan_phase"  default="0"/>
+  <arg name="return_mode" default="Dual"/>
   <arg name="model" default="Pandar40P"/>
   <arg name="frame_id" default="pandar"/>
   <arg name="calibration"  default="$(find pandar_pointcloud)/config/40p.csv"/>
@@ -32,6 +33,7 @@
     <remap from="pandar_points" to="pointcloud_raw" />
     <remap from="pandar_points_ex" to="pointcloud_raw_ex" />
     <param name="scan_phase" type="double" value="$(arg scan_phase)"/>
+    <param name="return_mode"  type="string" value="$(arg return_mode)"/>
     <param name="model" type="string" value="$(arg model)"/>
     <param name="device_ip" type="string" value="$(arg device_ip)"/>
     <param name="calibration" type="string" value="$(arg calibration)"/>

--- a/pandar_pointcloud/launch/pandarQT.launch
+++ b/pandar_pointcloud/launch/pandarQT.launch
@@ -7,6 +7,7 @@
   <arg name="gps_port"  default="10110"/>
   <arg name="scan_phase"  default="0"/>
   <arg name="return_mode" default="Dual"/>
+  <arg name="dual_return_distance_threshold" default="0.1"/>
   <arg name="model" default="PandarQT"/>
   <arg name="frame_id" default="pandar"/>
   <arg name="calibration"  default="$(find pandar_pointcloud)/config/qt.csv"/>
@@ -34,6 +35,7 @@
     <remap from="pandar_points_ex" to="pointcloud_raw_ex" />
     <param name="scan_phase" type="double" value="$(arg scan_phase)"/>
     <param name="return_mode"  type="string" value="$(arg return_mode)"/>
+    <param name="dual_return_distance_threshold"  type="double" value="$(arg dual_return_distance_threshold)"/>
     <param name="model" type="string" value="$(arg model)"/>
     <param name="device_ip" type="string" value="$(arg device_ip)"/>
     <param name="calibration" type="string" value="$(arg calibration)"/>

--- a/pandar_pointcloud/launch/pandarQT.launch
+++ b/pandar_pointcloud/launch/pandarQT.launch
@@ -6,6 +6,7 @@
   <arg name="lidar_port"  default="2368"/>
   <arg name="gps_port"  default="10110"/>
   <arg name="scan_phase"  default="0"/>
+  <arg name="return_mode" default="Dual"/>
   <arg name="model" default="PandarQT"/>
   <arg name="frame_id" default="pandar"/>
   <arg name="calibration"  default="$(find pandar_pointcloud)/config/qt.csv"/>
@@ -32,6 +33,7 @@
     <remap from="pandar_points" to="pointcloud_raw" />
     <remap from="pandar_points_ex" to="pointcloud_raw_ex" />
     <param name="scan_phase" type="double" value="$(arg scan_phase)"/>
+    <param name="return_mode"  type="string" value="$(arg return_mode)"/>
     <param name="model" type="string" value="$(arg model)"/>
     <param name="device_ip" type="string" value="$(arg device_ip)"/>
     <param name="calibration" type="string" value="$(arg calibration)"/>

--- a/pandar_pointcloud/launch/pandar_cloud.launch
+++ b/pandar_pointcloud/launch/pandar_cloud.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="scan_phase"  default="0"/>
   <arg name="return_mode" default="Dual"/>
+  <arg name="dual_return_distance_threshold" default="0.1"/>
   <arg name="model" default="Pandar40P"/>
   <arg name="device_ip" default="192.168.1.201"/>
   <arg name="calibration"  default="$(find pandar_pointcloud)/config/40p.csv"/>
@@ -20,6 +21,7 @@
     <param name="scan_phase"  type="double" value="$(arg scan_phase)"/>
     <param name="model"  type="string" value="$(arg model)"/>
     <param name="return_mode"  type="string" value="$(arg return_mode)"/>
+    <param name="dual_return_distance_threshold"  type="double" value="$(arg dual_return_distance_threshold)"/>
     <param name="device_ip" type="string" value="$(arg device_ip)"/>
   </node>
 </launch>

--- a/pandar_pointcloud/launch/pandar_cloud.launch
+++ b/pandar_pointcloud/launch/pandar_cloud.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="scan_phase"  default="0"/>
+  <arg name="return_mode" default="Dual"/>
   <arg name="model" default="Pandar40P"/>
   <arg name="device_ip" default="192.168.1.201"/>
   <arg name="calibration"  default="$(find pandar_pointcloud)/config/40p.csv"/>
@@ -18,6 +19,7 @@
         args="load pandar_pointcloud/CloudNodelet $(arg manager)">
     <param name="scan_phase"  type="double" value="$(arg scan_phase)"/>
     <param name="model"  type="string" value="$(arg model)"/>
+    <param name="return_mode"  type="string" value="$(arg return_mode)"/>
     <param name="device_ip" type="string" value="$(arg device_ip)"/>
   </node>
 </launch>

--- a/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
@@ -134,7 +134,7 @@ PointcloudXYZIRADT Pandar40Decoder::convert_dual(int block_id)
 {
   //   Under the Dual Return mode, the measurements from each round of firing are stored in two adjacent blocks:
   // · The even number block is the last return, and the odd number block is the strongest return
-  // · If the last and strongest returns coincide, the second strongest return will be placed in the odd number block  // · 
+  // · If the last and strongest returns coincide, the second strongest return will be placed in the odd number block
   // · The Azimuth changes every two blocks
   // · Important note: Hesai datasheet block numbering starts from 0, not 1, so odd/even are reversed here
   PointcloudXYZIRADT block_pc(new pcl::PointCloud<PointXYZIRADT>);
@@ -166,7 +166,7 @@ PointcloudXYZIRADT Pandar40Decoder::convert_dual(int block_id)
       block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::SINGLE_LAST)); 
     }
     else if (return_mode_ == ReturnMode::DUAL) {
-      //
+      // Only one return when returns are equal
       if (even_unit.distance == odd_unit.distance && even_usable) {
         block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::DUAL_ONLY));
       }

--- a/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
@@ -125,7 +125,7 @@ PointcloudXYZIRADT Pandar40Decoder::convert(int block_id)
   PointcloudXYZIRADT block_pc(new pcl::PointCloud<PointXYZIRADT>);
 
   for (auto unit_id : firing_order_) {
-    block_pc->push_back(build_point(block_id, unit_id, ReturnType::SINGLE_STRONGEST)); 
+    block_pc->push_back(build_point(block_id, unit_id, (packet_.return_mode == STRONGEST_RETURN) ? ReturnType::SINGLE_STRONGEST : ReturnType::SINGLE_LAST)); 
   }
   return block_pc;
 }

--- a/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
@@ -99,6 +99,7 @@ PointXYZIRADT Pandar40Decoder::build_point(int block_id, int unit_id, int8_t ret
   const auto& block = packet_.blocks[block_id];
   const auto& unit = block.units[unit_id];
   double unix_second = static_cast<double>(timegm(&packet_.t));
+  bool dual_return = (packet_.return_mode == DUAL_RETURN);
   PointXYZIRADT point;
 
   double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
@@ -115,7 +116,9 @@ PointXYZIRADT Pandar40Decoder::build_point(int block_id, int unit_id, int8_t ret
   point.azimuth = block.azimuth + round(azimuth_offset_[unit_id] * 100.0f);
   point.return_type = return_type;
   point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
-  point.time_stamp -= (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
+
+  point.time_stamp -= dual_return ? (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f) :
+                                    (static_cast<double>(block_offset_single_[block_id] + firing_offset_[unit_id]) / 1000000.0f); 
 
   return point;
 }

--- a/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
@@ -68,7 +68,15 @@ void Pandar40Decoder::unpack(const pandar_msgs::PandarPacket& raw_packet)
     has_scanned_ = false;
   }
 
-  bool dual_return = (packet_.echo == DUAL_ECHO);
+  bool dual_return = (packet_.return_mode == DUAL_RETURN);
+
+  if (!dual_return) {
+    if ((packet_.return_mode == STRONGEST_RETURN && return_mode_ != ReturnMode::STRONGEST) || 
+        (packet_.return_mode == LAST_RETURN && return_mode_ != ReturnMode::LAST)) {
+      ROS_WARN ("Sensor return mode configuration does not match requested return mode");
+    }
+  }
+
   auto step = dual_return ? 2 : 1;
 
   for (int block_id = 0; block_id < BLOCKS_PER_PACKET; block_id += step) {
@@ -84,6 +92,32 @@ void Pandar40Decoder::unpack(const pandar_msgs::PandarPacket& raw_packet)
     last_phase_ = current_phase;
   }
   return;
+}
+
+PointXYZIRADT Pandar40Decoder::build_point(int block_id, int unit_id, int8_t return_type)
+{
+  const auto& block = packet_.blocks[block_id];
+  const auto& unit = block.units[unit_id];
+  double unix_second = static_cast<double>(timegm(&packet_.t));
+  PointXYZIRADT point;
+
+  double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
+
+  point.x = static_cast<float>(
+      xyDistance * sinf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
+  point.y = static_cast<float>(
+      xyDistance * cosf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
+  point.z = static_cast<float>(unit.distance * sinf(deg2rad(elev_angle_[unit_id])));
+
+  point.intensity = unit.intensity;
+  point.distance = unit.distance;
+  point.ring = unit_id;
+  point.azimuth = block.azimuth + round(azimuth_offset_[unit_id] * 100.0f);
+  point.return_type = return_type;
+  point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
+  point.time_stamp -= (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
+
+  return point;
 }
 
 PointcloudXYZIRADT Pandar40Decoder::convert(int block_id)
@@ -117,6 +151,8 @@ PointcloudXYZIRADT Pandar40Decoder::convert(int block_id)
     point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
     point.time_stamp -= (static_cast<double>(block_offset_single_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
 
+    point.return_type = ((packet_.return_mode == STRONGEST_RETURN) ? ReturnType::SINGLE_STRONGEST : ReturnType::SINGLE_LAST);
+
     block_pc->push_back(point);
   }
   return block_pc;
@@ -125,42 +161,61 @@ PointcloudXYZIRADT Pandar40Decoder::convert(int block_id)
 PointcloudXYZIRADT Pandar40Decoder::convert_dual(int block_id)
 {
   //   Under the Dual Return mode, the measurements from each round of firing are stored in two adjacent blocks:
-  // · The odd number block is the last return, and the even number block is the strongest return
-  // · If the last and strongest returns coincide, the second strongest return will be placed in the even number block
+  // · The even number block is the last return, and the odd number block is the strongest return
+  // · If the last and strongest returns coincide, the second strongest return will be placed in the odd number block  // · 
   // · The Azimuth changes every two blocks
+  // · Important note: Hesai datasheet block numbering starts from 0, not 1, so odd/even are reversed here
   PointcloudXYZIRADT block_pc(new pcl::PointCloud<PointXYZIRADT>);
-  double unix_second = static_cast<double>(timegm(&packet_.t));
 
-  auto head = block_id + ((return_mode_ == ReturnMode::STRONGEST) ? 1 : 0);
-  auto tail = block_id + ((return_mode_ == ReturnMode::LAST) ? 1 : 2);
+  int even_block_id = block_id;
+  int odd_block_id = block_id + 1;
+  const auto& even_block = packet_.blocks[even_block_id];
+  const auto& odd_block = packet_.blocks[odd_block_id];
 
   for (auto unit_id : firing_order_) {
-    for (int i = head; i < tail; ++i) {
-      PointXYZIRADT point;
-      const auto& block = packet_.blocks[i];
-      const auto& unit = block.units[unit_id];
-      // skip invalid points
-      if (unit.distance <= 0.1 || unit.distance > 200.0) {
-        continue;
+
+    const auto& even_unit = even_block.units[unit_id];
+    const auto& odd_unit = odd_block.units[unit_id];
+
+    bool even_usable = (even_unit.distance <= 0.1 || even_unit.distance > 200.0) ? 0 : 1;
+    bool odd_usable = (odd_unit.distance <= 0.1 || odd_unit.distance > 200.0) ? 0 : 1;  
+
+    if (return_mode_ == ReturnMode::STRONGEST) {
+      // Strongest return is in even block when both returns coincide
+      if (even_unit.intensity >= odd_unit.intensity && even_usable) {
+        block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::SINGLE_STRONGEST));        
       }
-      double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
-
-      point.x = static_cast<float>(
-          xyDistance * sinf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
-      point.y = static_cast<float>(
-          xyDistance * cosf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
-      point.z = static_cast<float>(unit.distance * sinf(deg2rad(elev_angle_[unit_id])));
-
-      point.intensity = unit.intensity;
-      point.distance = unit.distance;
-
-      point.ring = unit_id;
-      point.azimuth = block.azimuth;
-
-      point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
-      point.time_stamp -= (static_cast<double>(block_offset_dual_[i] + firing_offset_[unit_id]) / 1000000.0f);
-
-      block_pc->push_back(point);
+      else if (even_unit.intensity < odd_unit.intensity && odd_usable) {
+        block_pc->push_back(build_point(odd_block_id, unit_id, ReturnType::SINGLE_STRONGEST)); 
+      }      
+    }
+    else if (return_mode_ == ReturnMode::LAST && even_usable) {
+      // Last return is always in even block
+      block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::SINGLE_LAST)); 
+    }
+    else if (return_mode_ == ReturnMode::DUAL) {
+      //
+      if (even_unit.distance == odd_unit.distance && even_usable) {
+        block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::DUAL_ONLY));
+      }
+      else if (even_unit.intensity >= odd_unit.intensity) {
+        // Strongest return is in even block when it is also the last
+        if (odd_usable) {
+          block_pc->push_back(build_point(odd_block_id, unit_id, ReturnType::DUAL_WEAK_FIRST));
+        }
+        if (even_usable) {
+          block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::DUAL_STRONGEST_LAST));
+        }
+      }
+      else {
+        // Normally, strongest return is in odd block and last return is in even block
+        if (odd_usable) {
+          block_pc->push_back(build_point(odd_block_id, unit_id, ReturnType::DUAL_STRONGEST_FIRST));
+        }
+        if (even_usable) {
+          block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::DUAL_WEAK_LAST));
+        }      
+      }
     }
   }
   return block_pc;
@@ -210,9 +265,9 @@ bool Pandar40Decoder::parsePacket(const pandar_msgs::PandarPacket& raw_packet)
   packet_.usec %= 1000000;
 
   index += TIMESTAMP_SIZE;
-  packet_.echo = buf[index] & 0xff;
+  packet_.return_mode = buf[index] & 0xff;
 
-  index += FACTORY_INFO_SIZE + ECHO_SIZE;
+  index += FACTORY_INFO_SIZE + RETURN_SIZE;
 
   packet_.t.tm_year = (buf[index + 0] & 0xff) + 100;
 

--- a/pandar_pointcloud/src/lib/decoder/pandar_qt_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar_qt_decoder.cpp
@@ -99,6 +99,7 @@ PointXYZIRADT PandarQTDecoder::build_point(int block_id, int unit_id, int8_t ret
   const auto& block = packet_.blocks[block_id];
   const auto& unit = block.units[unit_id];
   double unix_second = static_cast<double>(timegm(&packet_.t));
+  bool dual_return = (packet_.return_mode == DUAL_RETURN);
   PointXYZIRADT point;
 
   double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
@@ -115,7 +116,8 @@ PointXYZIRADT PandarQTDecoder::build_point(int block_id, int unit_id, int8_t ret
   point.azimuth = block.azimuth + round(azimuth_offset_[unit_id] * 100.0f);
   point.return_type = return_type;
   point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
-  point.time_stamp -= (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
+  point.time_stamp += dual_return ? (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f) :
+                                    (static_cast<double>(block_offset_single_[block_id] + firing_offset_[unit_id]) / 1000000.0f); 
 
   return point;
 }

--- a/pandar_pointcloud/src/lib/decoder/pandar_qt_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar_qt_decoder.cpp
@@ -69,8 +69,15 @@ void PandarQTDecoder::unpack(const pandar_msgs::PandarPacket& raw_packet)
     has_scanned_ = false;
   }
 
-  bool dual_return = (packet_.echo == DUAL_ECHO);
+  bool dual_return = (packet_.return_mode == DUAL_RETURN);
   auto step = dual_return ? 2 : 1;
+
+  if (!dual_return) {
+    if ((packet_.return_mode == FIRST_RETURN && return_mode_ != ReturnMode::FIRST) || 
+        (packet_.return_mode == LAST_RETURN && return_mode_ != ReturnMode::LAST)) {
+      ROS_WARN ("Sensor return mode configuration does not match requested return mode");
+    }
+  }
 
   for (int block_id = 0; block_id < BLOCK_NUM; block_id += step) {
     auto block_pc = dual_return ? convert_dual(block_id) : convert(block_id);
@@ -87,12 +94,35 @@ void PandarQTDecoder::unpack(const pandar_msgs::PandarPacket& raw_packet)
   return;
 }
 
+PointXYZIRADT PandarQTDecoder::build_point(int block_id, int unit_id, int8_t return_type)
+{
+  const auto& block = packet_.blocks[block_id];
+  const auto& unit = block.units[unit_id];
+  double unix_second = static_cast<double>(timegm(&packet_.t));
+  PointXYZIRADT point;
+
+  double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
+
+  point.x = static_cast<float>(
+      xyDistance * sinf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
+  point.y = static_cast<float>(
+      xyDistance * cosf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
+  point.z = static_cast<float>(unit.distance * sinf(deg2rad(elev_angle_[unit_id])));
+
+  point.intensity = unit.intensity;
+  point.distance = unit.distance;
+  point.ring = unit_id;
+  point.azimuth = block.azimuth + round(azimuth_offset_[unit_id] * 100.0f);
+  point.return_type = return_type;
+  point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
+  point.time_stamp -= (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
+
+  return point;
+}
+
 PointcloudXYZIRADT PandarQTDecoder::convert(const int block_id)
 {
   PointcloudXYZIRADT block_pc(new pcl::PointCloud<PointXYZIRADT>);
-
-  // double unix_second = raw_packet.header.stamp.toSec() // system-time (packet receive time)
-  double unix_second = static_cast<double>(timegm(&packet_.t));  // sensor-time (ppt/gps)
 
   const auto& block = packet_.blocks[block_id];
   for (size_t unit_id = 0; unit_id < UNIT_NUM; ++unit_id) {
@@ -102,65 +132,53 @@ PointcloudXYZIRADT PandarQTDecoder::convert(const int block_id)
     if (unit.distance <= 0.1 || unit.distance > 200.0) {
       continue;
     }
-    double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
-
-    point.x = static_cast<float>(
-        xyDistance * sinf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
-    point.y = static_cast<float>(
-        xyDistance * cosf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
-    point.z = static_cast<float>(unit.distance * sinf(deg2rad(elev_angle_[unit_id])));
-
-    point.intensity = unit.intensity;
-    point.distance = unit.distance;
-    point.ring = unit_id;
-    point.azimuth = block.azimuth + round(azimuth_offset_[unit_id] * 100.0f);
-
-    point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
-
-    point.time_stamp += (static_cast<double>(block_offset_single_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
-
-    block_pc->push_back(point);
+    block_pc->push_back(build_point(block_id, unit_id, (packet_.return_mode == FIRST_RETURN) ? ReturnType::SINGLE_FIRST : ReturnType::SINGLE_LAST));
   }
   return block_pc;
 }
 
 PointcloudXYZIRADT PandarQTDecoder::convert_dual(const int block_id)
 {
+  //   Under the Dual Return mode, the ranging data from each firing is stored in two adjacent blocks:
+  // · The even number block is the first return
+  // · The odd number block is the last return
+  // · The Azimuth changes every two blocks
+  // · Important note: Hesai datasheet block numbering starts from 0, not 1, so odd/even are reversed here 
   PointcloudXYZIRADT block_pc(new pcl::PointCloud<PointXYZIRADT>);
 
-  // double unix_second = raw_packet.header.stamp.toSec() // system-time (packet receive time)
-  double unix_second = static_cast<double>(timegm(&packet_.t));  // sensor-time (ppt/gps)
-
-  auto head = block_id + ((return_mode_ == ReturnMode::FIRST) ? 1 : 0);
-  auto tail = block_id + ((return_mode_ == ReturnMode::LAST) ? 1 : 2);
+  int even_block_id = block_id;
+  int odd_block_id = block_id + 1;
+  const auto& even_block = packet_.blocks[even_block_id];
+  const auto& odd_block = packet_.blocks[odd_block_id];
 
   for (size_t unit_id = 0; unit_id < UNIT_NUM; ++unit_id) {
-    for (int i = head; i < tail; ++i) {
-      PointXYZIRADT point;
-      const auto& block = packet_.blocks[i];
-      const auto& unit = block.units[unit_id];
-      // skip invalid points
-      if (unit.distance <= 0.1 || unit.distance > 200.0) {
-        continue;
+
+    const auto& even_unit = even_block.units[unit_id];
+    const auto& odd_unit = odd_block.units[unit_id];
+
+    bool even_usable = (even_unit.distance <= 0.1 || even_unit.distance > 200.0) ? 0 : 1;
+    bool odd_usable = (odd_unit.distance <= 0.1 || odd_unit.distance > 200.0) ? 0 : 1;  
+
+    if (return_mode_ == ReturnMode::FIRST && even_usable) {
+      // First return is in even block
+      block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::SINGLE_FIRST));     
+    }
+    else if (return_mode_ == ReturnMode::LAST && even_usable) {
+      // Last return is in odd block
+      block_pc->push_back(build_point(odd_block_id, unit_id, ReturnType::SINGLE_LAST)); 
+    }
+    else if (return_mode_ == ReturnMode::DUAL) {
+      if (even_unit.distance == odd_unit.distance && even_usable) {
+        block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::DUAL_ONLY));
       }
-      double xyDistance = unit.distance * cosf(deg2rad(elev_angle_[unit_id]));
-
-      point.x = static_cast<float>(
-          xyDistance * sinf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
-      point.y = static_cast<float>(
-          xyDistance * cosf(deg2rad(azimuth_offset_[unit_id] + (static_cast<double>(block.azimuth)) / 100.0)));
-      point.z = static_cast<float>(unit.distance * sinf(deg2rad(elev_angle_[unit_id])));
-
-      point.intensity = unit.intensity;
-      point.distance = unit.distance;
-      point.ring = unit_id;
-      point.azimuth = block.azimuth + round(azimuth_offset_[unit_id] * 100.0f);
-
-      point.time_stamp = unix_second + (static_cast<double>(packet_.usec)) / 1000000.0;
-
-      point.time_stamp += (static_cast<double>(block_offset_dual_[block_id] + firing_offset_[unit_id]) / 1000000.0f);
-
-      block_pc->push_back(point);
+      else {
+        if (even_usable) {
+          block_pc->push_back(build_point(even_block_id, unit_id, ReturnType::DUAL_FIRST));
+        }
+        if (odd_usable) {
+          block_pc->push_back(build_point(odd_block_id, unit_id, ReturnType::DUAL_LAST));
+        }
+      }
     }
   }
   return block_pc;
@@ -211,9 +229,9 @@ bool PandarQTDecoder::parsePacket(const pandar_msgs::PandarPacket& raw_packet)
                  ((buf[index + 3] & 0xff) << 24);
   index += TIMESTAMP_SIZE;
 
-  packet_.echo = buf[index] & 0xff;
+  packet_.return_mode = buf[index] & 0xff;
 
-  index += ECHO_SIZE;
+  index += RETURN_SIZE;
   index += FACTORY_SIZE;
 
   packet_.t.tm_year = (buf[index + 0] & 0xff) + 100;

--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -20,6 +20,7 @@ PandarCloud::PandarCloud(ros::NodeHandle node, ros::NodeHandle private_nh)
 {
   private_nh.getParam("scan_phase", scan_phase_);
   private_nh.getParam("return_mode", return_mode_);
+  private_nh.getParam("dual_return_distance_threshold", dual_return_distance_threshold_);
   private_nh.getParam("calibration", calibration_path_);
   private_nh.getParam("model", model_);
   private_nh.getParam("device_ip", device_ip_);
@@ -43,6 +44,7 @@ PandarCloud::PandarCloud(ros::NodeHandle node, ros::NodeHandle private_nh)
       selected_return_mode = pandar40::Pandar40Decoder::ReturnMode::STRONGEST;
     }
     decoder_ = std::make_shared<pandar40::Pandar40Decoder>(calibration_, scan_phase_,
+                                                           dual_return_distance_threshold_,
                                                            selected_return_mode);
   }
   else if (model_ == "PandarQT") {
@@ -58,6 +60,7 @@ PandarCloud::PandarCloud(ros::NodeHandle node, ros::NodeHandle private_nh)
       selected_return_mode = pandar_qt::PandarQTDecoder::ReturnMode::DUAL;
     }
     decoder_ = std::make_shared<pandar_qt::PandarQTDecoder>(calibration_, scan_phase_,
+                                                            dual_return_distance_threshold_,
                                                             selected_return_mode);
   }
   else {


### PR DESCRIPTION
Add return type to Pandar40P and PandarQT point types.

- The different devices handle multiple returns differently so classification of return type must be different
- When the sensor is in dual return mode, the user can select to publish only "Strongest" or "Last" (for Pandar 40P) or "First" or "Last" (for PandarQT) with the parameter `return_mode`
- If the device is in a setting that does not allow publishing to match the `return_mode` parameter (for example "Strongest" requested when the sensor is in "Last" mode) then a warning is issued. Therefore this setting is only useful when the sensor is in "Dual" mode.

Notes:
Tested on Pandar QT and Pandar40P packets data in dual mode.
Tested on Pandar QT and Pandar40P dual / strongest / last pcaps.