### PR TITLE
Change data type of return_type to uint8

### DIFF
--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar40_decoder.hpp
@@ -19,7 +19,7 @@ public:
     STRONGEST,
     LAST,
   };
-  enum ReturnType : int8_t
+  enum ReturnType : uint8_t
   {
     INVALID = 0,
     SINGLE_STRONGEST,
@@ -41,7 +41,7 @@ private:
   rclcpp::Clock::SharedPtr clock_;
 
   bool parsePacket(const pandar_msgs::msg::PandarPacket& raw_packet);
-  PointXYZIRADT build_point(int block_id, int unit_id, int8_t return_type);
+  PointXYZIRADT build_point(int block_id, int unit_id, uint8_t return_type);
   PointcloudXYZIRADT convert(const int block_id);
   PointcloudXYZIRADT convert_dual(const int block_id);
 

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar64_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar64_decoder.hpp
@@ -19,7 +19,7 @@ namespace pandar_pointcloud
         STRONGEST,
         LAST,
       };
-      enum ReturnType : int8_t
+      enum ReturnType : uint8_t
       {
         INVALID = 0,
         SINGLE_STRONGEST,
@@ -37,7 +37,7 @@ namespace pandar_pointcloud
 
       void unpack(const pandar_msgs::msg::PandarPacket& raw_packet) override;
 
-      PointXYZIRADT build_point(int block_id, int unit_id, int8_t return_type);
+      PointXYZIRADT build_point(int block_id, int unit_id, uint8_t return_type);
 
       bool hasScanned() override;
 

--- a/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/decoder/pandar_qt_decoder.hpp
@@ -19,7 +19,7 @@ public:
     FIRST,
     LAST,
   };
-  enum ReturnType : int8_t
+  enum ReturnType : uint8_t
   {
     INVALID = 0,
     SINGLE_FIRST,
@@ -31,7 +31,7 @@ public:
 
   PandarQTDecoder(rclcpp::Node & node, Calibration& calibration, float scan_phase = 0.0f, double dual_return_distance_threshold = 0.1, ReturnMode return_mode = ReturnMode::DUAL);
   void unpack(const pandar_msgs::msg::PandarPacket& raw_packet) override;
-  PointXYZIRADT build_point(int block_id, int unit_id, int8_t return_type);
+  PointXYZIRADT build_point(int block_id, int unit_id, uint8_t return_type);
   bool hasScanned() override;
   PointcloudXYZIRADT getPointcloud() override;
 

--- a/pandar_pointcloud/include/pandar_pointcloud/point_types.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/point_types.hpp
@@ -21,7 +21,7 @@ struct PointXYZIRADT
   uint16_t ring;
   float azimuth;
   float distance;
-  int8_t return_type;
+  uint8_t return_type;
   double time_stamp;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
@@ -42,5 +42,5 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(pandar_pointcloud::PointXYZIRADT,
                                   (std::uint16_t, ring, ring)
                                   (float, azimuth, azimuth)
                                   (float, distance, distance)
-                                  (std::int8_t, return_type, return_type)
+                                  (std::uint8_t, return_type, return_type)
                                   (double, time_stamp, time_stamp))

--- a/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar40_decoder.cpp
@@ -96,7 +96,7 @@ void Pandar40Decoder::unpack(const pandar_msgs::msg::PandarPacket& raw_packet)
   return;
 }
 
-PointXYZIRADT Pandar40Decoder::build_point(int block_id, int unit_id, int8_t return_type)
+PointXYZIRADT Pandar40Decoder::build_point(int block_id, int unit_id, uint8_t return_type)
 {
   const auto& block = packet_.blocks[block_id];
   const auto& unit = block.units[unit_id];

--- a/pandar_pointcloud/src/lib/decoder/pandar64_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar64_decoder.cpp
@@ -98,7 +98,7 @@ namespace pandar_pointcloud
       }
     }
 
-    PointXYZIRADT Pandar64Decoder::build_point(int block_id, int unit_id, int8_t return_type)
+    PointXYZIRADT Pandar64Decoder::build_point(int block_id, int unit_id, uint8_t return_type)
     {
       const auto& block = packet_.blocks[block_id];
       const auto& unit = block.units[unit_id];

--- a/pandar_pointcloud/src/lib/decoder/pandar_qt_decoder.cpp
+++ b/pandar_pointcloud/src/lib/decoder/pandar_qt_decoder.cpp
@@ -96,7 +96,7 @@ void PandarQTDecoder::unpack(const pandar_msgs::msg::PandarPacket& raw_packet)
   return;
 }
 
-PointXYZIRADT PandarQTDecoder::build_point(int block_id, int unit_id, int8_t return_type)
+PointXYZIRADT PandarQTDecoder::build_point(int block_id, int unit_id, uint8_t return_type)
 {
   const auto& block = packet_.blocks[block_id];
   const auto& unit = block.units[unit_id];


### PR DESCRIPTION
velodyne_vlsに合わせてdual return filter およびHesai pandarもreturn_typeの型をint8_tからuint8_tに変更する。https://github.com/tier4/velodyne_vls/pull/23#discussion_r704857617

Related PR
https://github.com/tier4/autoware.iv/pull/2020
https://github.com/tier4/velodyne_vls/pull/23

Review Procedure
変更箇所に過不足がないことを確認する
https://github.com/tier4/autoware.iv/pull/2020 と結合して意図通り動くことを確認する