### PR TITLE
feat: publish null pointc cloud

### DIFF
--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -164,28 +164,28 @@ void PandarCloud::onProcessScan(const pandar_msgs::msg::PandarScan::SharedPtr sc
   pandar_msgs::msg::PandarPacket pkt;
 
   for (auto& packet : scan_msg->packets) {
-    // RCLCPP_WARN(get_logger(), "-------- unpack ----------");
     decoder_->unpack(packet);
   }
   pointcloud = decoder_->getPointcloud();
+  rclcpp::Time pointcloud_stamp;
   if (pointcloud->points.size() > 0) {
     double first_point_timestamp = pointcloud->points.front().time_stamp;
-    pointcloud->header.frame_id = scan_msg->header.frame_id;
-    if (pandar_points_pub_->get_subscription_count() > 0) {
-      const auto pointcloud_raw = convertPointcloud(pointcloud);
-      auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-      pcl::toROSMsg(*pointcloud_raw, *ros_pc_msg_ptr);
-      ros_pc_msg_ptr->header.stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
-      pandar_points_pub_->publish(std::move(ros_pc_msg_ptr));
-    }
-    {
-      // RCLCPP_WARN(get_logger(),"========== publish %ld points. ==========", pointcloud->points.size()); 
-      auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-      pcl::toROSMsg(*pointcloud, *ros_pc_msg_ptr);
-      ros_pc_msg_ptr->header.stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
-      pandar_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
-    }
+    pointcloud_stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
+  } else{
+    pointcloud_stamp = scan_msg->header.stamp;
   }
+  pointcloud->header.frame_id = scan_msg->header.frame_id;
+  if (pandar_points_pub_->get_subscription_count() > 0) {
+    const auto pointcloud_raw = convertPointcloud(pointcloud);
+    auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*pointcloud_raw, *ros_pc_msg_ptr);
+    ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
+    pandar_points_pub_->publish(std::move(ros_pc_msg_ptr));
+  }
+  auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
+  pcl::toROSMsg(*pointcloud, *ros_pc_msg_ptr);
+  ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
+  pandar_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
 }
 
 pcl::PointCloud<PointXYZIR>::Ptr


### PR DESCRIPTION
Changed to output point clouds even if the contents of PandarPackets are empty
- In this case, the header timestamp is taken from PandarPackaets