### PR TITLE
fix: strongest setting of xt32

### DIFF
--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -81,7 +81,7 @@ PandarCloud::PandarCloud(const rclcpp::NodeOptions & options)
     pandar_xt::PandarXTDecoder::ReturnMode selected_return_mode;
     if (return_mode_ == "First")
       selected_return_mode = pandar_xt::PandarXTDecoder::ReturnMode::FIRST;
-    else if (return_mode_ == "STRONGEST")
+    else if (return_mode_ == "Strongest")
       selected_return_mode = pandar_xt::PandarXTDecoder::ReturnMode::STRONGEST;
     else if (return_mode_ == "Last")
       selected_return_mode = pandar_xt::PandarXTDecoder::ReturnMode::LAST;


### PR DESCRIPTION
fix: strongest setting of xt-32

naming should be same as 
```
  if (model_ == "Pandar40P" || model_ == "Pandar40M") {
    pandar40::Pandar40Decoder::ReturnMode selected_return_mode;
    if (return_mode_ == "Strongest")
      selected_return_mode = pandar40::Pandar40Decoder::ReturnMode::STRONGEST;
```
https://star4.slack.com/archives/C024FRX4UNL/p1681127348450529?thread_ts=1681091631.872489&cid=C024FRX4UNL