### PR TITLE
fix(tcp_client): assign a value when successful

### DIFF
--- a/pandar_api/src/tcp_client.cpp
+++ b/pandar_api/src/tcp_client.cpp
@@ -267,6 +267,7 @@ void TCPClient::on_receive(const boost::system::error_code& error)
             return_code_ = ReturnCode::CONNECTION_FAILED;
           }
           else {
+            return_code_ = (ReturnCode)header_.return_code;
             socket_.close();
             timer_.cancel();
             return;


### PR DESCRIPTION
pandar monitor was Error even after pandar reconnected after the connection was interrupted.

As a result of the analysis, the return mode is not updated when data is successfully received by on_receive. Therefore, it does not enter the OK status after reconnection.

## Related Link(T4 internal)
https://tier4.atlassian.net/browse/AEAP-482