### PR TITLE
fix(pandar_driver): make pandar_pointcloud buildable

### DIFF
--- a/pandar_pointcloud/CMakeLists.txt
+++ b/pandar_pointcloud/CMakeLists.txt
@@ -16,6 +16,9 @@ find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 ament_auto_find_build_dependencies()
 
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
 include_directories(
   include
   ${PCL_INCLUDE_DIRS}
@@ -33,6 +36,7 @@ ament_auto_add_library(pandar_cloud SHARED
   src/lib/decoder/pandar64_decoder.cpp
 )
 
+target_link_libraries(pandar_cloud ${PCL_LIBRARIES})
 
 rclcpp_components_register_node(pandar_cloud
   PLUGIN "pandar_pointcloud::PandarCloud"

--- a/pandar_pointcloud/include/pandar_pointcloud/calibration.hpp
+++ b/pandar_pointcloud/include/pandar_pointcloud/calibration.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <map>
+#include <string>
 
 namespace pandar_pointcloud
 {


### PR DESCRIPTION
In my environment this package could not build, so I followed [this guide](https://pointclouds.org/documentation/tutorials/using_pcl_pcl_config.html) and updated CMakeLists.txt.