### PR TITLE
feat(pandar_cloud): prevent point cloud data loss

### DIFF
--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -165,30 +165,29 @@ void PandarCloud::onProcessScan(const pandar_msgs::msg::PandarScan::SharedPtr sc
 
   for (auto& packet : scan_msg->packets) {
     decoder_->unpack(packet);
-    if(!decoder_->hasScanned()) {
-      continue;
+    if(decoder_->hasScanned()) {
+      pointcloud = decoder_->getPointcloud();
     }
-    pointcloud = decoder_->getPointcloud();
-    rclcpp::Time pointcloud_stamp;
-    if (pointcloud->points.size() > 0) {
-      double first_point_timestamp = pointcloud->points.front().time_stamp;
-      pointcloud_stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
-    } else{
-      pointcloud_stamp = scan_msg->header.stamp;
-    }
-    pointcloud->header.frame_id = scan_msg->header.frame_id;
-    if (pandar_points_pub_->get_subscription_count() > 0) {
-      const auto pointcloud_raw = convertPointcloud(pointcloud);
-      auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-      pcl::toROSMsg(*pointcloud_raw, *ros_pc_msg_ptr);
-      ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
-      pandar_points_pub_->publish(std::move(ros_pc_msg_ptr));
-    }
-    auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*pointcloud, *ros_pc_msg_ptr);
-    ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
-    pandar_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
   }
+  rclcpp::Time pointcloud_stamp;
+  if (pointcloud->points.size() > 0) {
+    double first_point_timestamp = pointcloud->points.front().time_stamp;
+    pointcloud_stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
+  } else{
+    pointcloud_stamp = scan_msg->header.stamp;
+  }
+  pointcloud->header.frame_id = scan_msg->header.frame_id;
+  if (pandar_points_pub_->get_subscription_count() > 0) {
+    const auto pointcloud_raw = convertPointcloud(pointcloud);
+    auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*pointcloud_raw, *ros_pc_msg_ptr);
+    ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
+    pandar_points_pub_->publish(std::move(ros_pc_msg_ptr));
+  }
+  auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
+  pcl::toROSMsg(*pointcloud, *ros_pc_msg_ptr);
+  ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
+  pandar_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
 }
 
 pcl::PointCloud<PointXYZIR>::Ptr

--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -162,30 +162,32 @@ void PandarCloud::onProcessScan(const pandar_msgs::msg::PandarScan::SharedPtr sc
 {
   PointcloudXYZIRADT pointcloud;
   pandar_msgs::msg::PandarPacket pkt;
-
+  
   for (auto& packet : scan_msg->packets) {
     decoder_->unpack(packet);
+    if(decoder_->hasScanned()) {
+      pointcloud = decoder_->getPointcloud();
+      rclcpp::Time pointcloud_stamp;
+      if (pointcloud->points.size() > 0) {
+        double first_point_timestamp = pointcloud->points.front().time_stamp;
+        pointcloud_stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
+      } else{
+        pointcloud_stamp = scan_msg->header.stamp;
+      }
+      pointcloud->header.frame_id = scan_msg->header.frame_id;
+      if (pandar_points_pub_->get_subscription_count() > 0) {
+        const auto pointcloud_raw = convertPointcloud(pointcloud);
+        auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
+        pcl::toROSMsg(*pointcloud_raw, *ros_pc_msg_ptr);
+        ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
+        pandar_points_pub_->publish(std::move(ros_pc_msg_ptr));
+      }
+      auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
+      pcl::toROSMsg(*pointcloud, *ros_pc_msg_ptr);
+      ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
+      pandar_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
+    }
   }
-  pointcloud = decoder_->getPointcloud();
-  rclcpp::Time pointcloud_stamp;
-  if (pointcloud->points.size() > 0) {
-    double first_point_timestamp = pointcloud->points.front().time_stamp;
-    pointcloud_stamp = rclcpp::Time(toChronoNanoSeconds(first_point_timestamp).count());
-  } else{
-    pointcloud_stamp = scan_msg->header.stamp;
-  }
-  pointcloud->header.frame_id = scan_msg->header.frame_id;
-  if (pandar_points_pub_->get_subscription_count() > 0) {
-    const auto pointcloud_raw = convertPointcloud(pointcloud);
-    auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*pointcloud_raw, *ros_pc_msg_ptr);
-    ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
-    pandar_points_pub_->publish(std::move(ros_pc_msg_ptr));
-  }
-  auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-  pcl::toROSMsg(*pointcloud, *ros_pc_msg_ptr);
-  ros_pc_msg_ptr->header.stamp = pointcloud_stamp;
-  pandar_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
 }
 
 pcl::PointCloud<PointXYZIR>::Ptr


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- hesai_driverであるhesai_pandarのpandar_pointcloudにセンサーを振動させた時に点群欠落が発生するのを防ぐ処理を追加します。

## Related links

<!-- Write the links related to this PR. -->
- [設計資料の場所](https://tier4.atlassian.net/browse/AEAP-1465)
- [評価資料の場所](https://tier4.atlassian.net/browse/AEAP-1466)
- [修正参考コード](https://github.com/MapIV/hesai_pandar/tree/ros2)

### 変更内容
- Lidarデータパケットを1トピック分を全てPointCloudへ変換して出力するのではなく、LiDARデータパケット内でLiDARデータの終端を判定し、そこまでのデータをPointCloudへ変換して出力するするように処理を変更。
![Hesai点群欠落修正方針](https://github.com/user-attachments/assets/4739167d-29eb-4cf8-aa16-efb4595f38ec)


    - LiDARデータの終端判定処理は元々pandar_pointcloudに存在していたので、LiDARデータパケット毎にその判定処理を呼び出してLiDARデータ終端を判定し、終端に到達していた場合はそれまでのデータをPointCloudへ変換してPublishするようにしています。

## Tests performed

### 機能検証
- 修正後のhesai_driverでセンサを2分間振動させた場合に点群欠落が発生しないことが確認できています。

- 同じセンサーを用いて修正前のhesai_driverでセンサーを振動させると点群欠落が多数発生しているため、hesai_driverの修正で改善していることが確認できています。
  - 修正前
![org_point_cloud](https://github.com/user-attachments/assets/4ef70860-c2b4-4209-b085-967b6a15269a)
    - 修正前hesai_driverでセンサ振動時のPointCloudデータの点群数(field widthの値)
[point_cloud_width_org_driver.log](https://github.com/user-attachments/files/16938066/point_cloud_width_org_driver.log)

  - 修正後
![fixed_point_cloud](https://github.com/user-attachments/assets/bc95949d-e8d8-4fdd-9db6-37dd287b959b)
    - 修正後hesai_driverでセンサ振動時のPointCloudデータの点群数(field widthの値)
[pointcloud_width_fixed_driver.log](https://github.com/user-attachments/files/16938070/pointcloud_width_fixed_driver.log)


- 修正後のhesai_driverのpandar_pointcloudから出力されるPointCloudデータの点群数(field widthの値)も振動時に点群欠落時の異常値である200点程度の値が出ないことが確認できています。
 
  [topic_echo_pointcloud.txt](https://github.com/user-attachments/files/16883874/topic_echo_pointcloud.txt)


- 修正後のhesai_pandarを使用して2時間連続して実行した場合にpandar_pointcloudからエラーや異常な警告の出力、異常終了がないことが確認できています。

  [pandar_launch_run.log](https://github.com/user-attachments/files/16939204/pandar_launch_run.log)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/