### PR TITLE
fix(pandar_cloud): fixed an issue to packet alignment

### DIFF
--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -162,16 +162,16 @@ void PandarCloud::onProcessScan(const pandar_msgs::msg::PandarScan::SharedPtr sc
 {
   PointcloudXYZIRADT pointcloud;
   pandar_msgs::msg::PandarPacket pkt;
-  bool is_hasScanned = false;
+  bool never_detected_scan_boundary = true;
 
   for (auto& packet : scan_msg->packets) {
     decoder_->unpack(packet);
     if(decoder_->hasScanned()) {
       pointcloud = decoder_->getPointcloud();
-      is_hasScanned = true;
+      never_detected_scan_boundary = false;
     }
   }
-  if (!is_hasScanned) {
+  if (never_detected_scan_boundary) {
     pointcloud = decoder_->getPointcloud();
   }
   rclcpp::Time pointcloud_stamp;

--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -162,12 +162,17 @@ void PandarCloud::onProcessScan(const pandar_msgs::msg::PandarScan::SharedPtr sc
 {
   PointcloudXYZIRADT pointcloud;
   pandar_msgs::msg::PandarPacket pkt;
+  bool is_hasScanned = false;
 
   for (auto& packet : scan_msg->packets) {
     decoder_->unpack(packet);
     if(decoder_->hasScanned()) {
       pointcloud = decoder_->getPointcloud();
+      is_hasScanned = true;
     }
+  }
+  if (!is_hasScanned) {
+    pointcloud = decoder_->getPointcloud();
   }
   rclcpp::Time pointcloud_stamp;
   if (pointcloud->points.size() > 0) {


### PR DESCRIPTION
## Description

このPRはLiDARデータパケットが入力された際にPointCloudデータ出力が停止する不具合を修正するものである。
調査の結果、ある条件においてプロセスが死亡する問題があることが分かった。本PRではこの問題に対処するため、ノード死亡原因を無くす修正する。
  PointCloudデータの取得処理において、データが格納されない例外条件でノードが死亡していたため、データの格納条件を変更する。
  データが格納されない条件とはデータ格納のforループの中で一度もパケットデータの連番が戻らないとき。
  上記条件においてforループ後にデータを格納する。
これにより、ノード死亡原因が是正される。

### 修正内容

- 現状登録済みの処理は以下のようになっており、パケットデータの連番が戻らないとき(1周期分のパケットの終端に次のパケットのデータが含まれない場合)にPointCloudがpublish領域にコピーされない問題があります。
![現状の処理r2](https://github.com/user-attachments/assets/a9d9eaa7-b93a-413d-b162-707f710277bf)


- 上記問題を解決するために、パケットデータにズレがない場合は全データをPointCloudへデコードした後にPointCloudデータをpublish領域にコピーする処理を追加しました。
![修正後の処理r2](https://github.com/user-attachments/assets/bd555dc0-8192-4a2b-ae8a-85d50d76a366)



### この修正による変化

- 今回の修正でパケットデータの連番が戻らないとき(1周期分のパケットの終端に次のパケットのデータが含まれない場合)に受信時のPointCloudと次周期のPointCloudで同じデータが出力されるようになります。


<!-- Write a brief description of this PR. -->

## Related links

- [課題チケット](https://tier4.atlassian.net/browse/AEAP-1834)

<!-- Write the links related to this PR. -->

## Tests performed

### 機能評価
以下のrosbagを入力データとして確認をしました。
- rvizでPointCloudが途中で停止せず出力され続けることを確認済みです。
- hesai_pandarでデータの出力停止がないことを確認済みです。


#### rosbagファイル
[Os_LSim-1-001_Night_Sunny_Flat_Headlight_Tugnova_XT32_Detection](https://evaluation.tier4.jp/evaluation/reports/125459cf-dd8c-5944-bf73-8113f0e15bdf/tests/dca7f238-16c9-5341-8531-944c42e8f580/61267e5d-f444-5175-8ddc-cd345bf97949/d17b9d9c-5b6f-5140-896d-2c8a02de29a9?project_id=odd2_reference)

[Os_LSim-1-001_Night_Sunny_Flat_Headlight_Fork_XT32_Detection](https://evaluation.tier4.jp/evaluation/reports/c7b7433f-5aa3-5866-a1ca-e9f6e59d0096/tests/7d3d0263-9109-5195-a9a0-1b7c99f7d349/4df0d8b9-24e9-5465-9cd6-ef930025f686/67563970-1299-59b0-9b84-009fd9327d05?project_id=odd2_reference)

[Os_LSim-1-001_Night_Sunny_Flat_Headlight_None_XT32_NonDetection](https://evaluation.tier4.jp/evaluation/reports/26e64897-8233-51da-bada-869846377e96/tests/cad981ac-504d-577f-8461-8e5e4b49cc0b/39552a20-2835-5e6c-8cb5-cbabb7433a7e/9d877305-d0fb-5d74-acd5-523f7db68926?project_id=odd2_reference)

### リグレッション評価
異常が発生する条件にあてはまらないときに出力されるPointCloudに変化がないことは確認済みです。

 - 点群欠落確認時のPointCloudトピックのwidth値(点群数)：
[360_pointcloud_width.log](https://github.com/user-attachments/files/17499849/360_pointcloud_width.log)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/